### PR TITLE
🤐 Add `mask-password` flag to ECR login

### DIFF
--- a/.github/workflows/reusable-workflow-containers.yml
+++ b/.github/workflows/reusable-workflow-containers.yml
@@ -164,6 +164,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login_ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1.7.0
+        with:
+          mask-password: 'true'
 
       - name: Prepare Environment
         id: prepare_environment


### PR DESCRIPTION
Resolves

> [!WARNING]
Your docker password is not masked...

Source: https://github.com/aws-actions/amazon-ecr-login#docker-credentials