### PR TITLE
📌 Update AWS SSO Sync image tag

### DIFF
--- a/terraform/aws/accounts/root/sso/lambda-functions.tf
+++ b/terraform/aws/accounts/root/sso/lambda-functions.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "aws_sso_sync" {
   #ts:skip=AC_AWS_0484
   function_name = "aws-sso-sync"
   package_type  = "Image"
-  image_uri     = "126246520815.dkr.ecr.eu-west-2.amazonaws.com/aws-ssosync:0.0.7"
+  image_uri     = "126246520815.dkr.ecr.eu-west-2.amazonaws.com/aws-ssosync:2.0.3"
   role          = aws_iam_role.aws_sso_sync.arn
   timeout       = 15
 


### PR DESCRIPTION
Bump to `2.0.3`

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>