### PR TITLE
🔥 Remove group match from SSO sync

### DIFF
--- a/containers/aws-ssosync/CHANGELOG.md
+++ b/containers/aws-ssosync/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3.2] - 2023-11-04
+
+### Changed
+
+- Remove `--group-match`, sync all the groups
+
 ## [2.0.3.1] - 2023-10-23
 
 ### Changed

--- a/containers/aws-ssosync/config.json
+++ b/containers/aws-ssosync/config.json
@@ -1,4 +1,4 @@
 {
   "name": "aws-ssosync",
-  "version": "2.0.3.1"
+  "version": "2.0.3.2"
 }

--- a/containers/aws-ssosync/src/var/task/function.sh
+++ b/containers/aws-ssosync/src/var/task/function.sh
@@ -15,8 +15,7 @@ function handler() {
     --endpoint "${AWS_SSO_SYNC_SCIM_ENDPOINT}" \
     --google-admin "${AWS_SSO_SYNC_GOOGLE_ADMIN}" \
     --google-credentials /tmp/credentials.json \
-    --sync-method "groups" \
-    --group-match "${AWS_SSO_SYNC_GROUP_MATCH}"
+    --sync-method "groups"
 
   if [ $? -eq 0 ]; then
     echo "Successfully synced groups"


### PR DESCRIPTION
This pull request removes the `--group-match` option from the `aws-ssosync` script and bumps the version to `2.0.3.2`

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>