### PR TITLE
⬆️ Bump docs Python to 3.12

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
         id: setup_python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Configure Pages
         id: configure_pages

--- a/scripts/docs/run.sh
+++ b/scripts/docs/run.sh
@@ -8,5 +8,5 @@ docker run -it --rm \
   --workdir /docs \
   --publish 8000:8000 \
   --entrypoint /bin/bash \
-  public.ecr.aws/docker/library/python:3.10-slim \
+  public.ecr.aws/docker/library/python:3.12-slim \
   /scripts/docs/preview.sh


### PR DESCRIPTION
This pull request:

- Bump docs Python to 3.12 in preview script and GitHub Actions workflow

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>