### PR TITLE
:shipit: Deploy new aws-ssosync

### DIFF
--- a/terraform/aws/root/organisation/data.tf
+++ b/terraform/aws/root/organisation/data.tf
@@ -30,6 +30,14 @@ data "aws_secretsmanager_secret_version" "aws_sso_sync_google_credentials" {
   secret_id = "aws-sso-sync/google-credentials"
 }
 
+data "aws_secretsmanager_secret_version" "aws_sso_sync_ignore_groups" {
+  secret_id = "aws-sso-sync/ignore-groups"
+}
+
+data "aws_secretsmanager_secret_version" "aws_sso_sync_ignore_users" {
+  secret_id = "aws-sso-sync/ignore-users"
+}
+
 data "aws_secretsmanager_secret_version" "github_token" {
   secret_id = "github-robot-token"
 }

--- a/terraform/aws/root/organisation/lambda-functions.tf
+++ b/terraform/aws/root/organisation/lambda-functions.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "aws_sso_sync" {
   #ts:skip=AC_AWS_0484
   function_name = "aws-sso-sync"
   package_type  = "Image"
-  image_uri     = "126246520815.dkr.ecr.eu-west-2.amazonaws.com/aws-ssosync:2.0.3.2"
+  image_uri     = "126246520815.dkr.ecr.eu-west-2.amazonaws.com/aws-ssosync:2.1.2"
   role          = aws_iam_role.aws_sso_sync.arn
   timeout       = 600
 
@@ -18,6 +18,8 @@ resource "aws_lambda_function" "aws_sso_sync" {
       AWS_SSO_SYNC_LOG_LEVEL          = "debug"
       AWS_SSO_SYNC_SCIM_ENDPOINT      = data.aws_secretsmanager_secret_version.aws_sso_sync_scim_endpoint.secret_string
       AWS_SSO_SYNC_SCIM_TOKEN         = data.aws_secretsmanager_secret_version.aws_sso_sync_scim_token.secret_string
+      AWS_SSO_SYNC_IGNORE_GROUPS      = data.aws_secretsmanager_secret_version.aws_sso_sync_ignore_groups.secret_string
+      AWS_SSO_SYNC_IGNORE_USERS       = data.aws_secretsmanager_secret_version.aws_sso_sync_ignore_users.secret_string
     }
   }
 }


### PR DESCRIPTION
This pull request:

- Deploys `aws-ssosync:2.1.2`
- Adds new variables
  - `AWS_SSO_SYNC_IGNORE_GROUPS`
  - `AWS_SSO_SYNC_IGNORE_USERS`

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>