### PR TITLE
🙉 Ignore comment changes on bny

### DIFF
--- a/terraform/cloudflare/records.tf
+++ b/terraform/cloudflare/records.tf
@@ -110,6 +110,9 @@ resource "cloudflare_record" "woffenden_net_bny_a" {
   comment = "This record is updated by the IP Update script"
 
   lifecycle {
-    ignore_changes = [value]
+    ignore_changes = [
+      comment,
+      value
+    ]
   }
 }


### PR DESCRIPTION
This pull request:

- Ignores changes to comments on `woffenden_net_bny_a` because its updated by a script running on Kubernetes

Signed-off-by: Jacob Woffenden <jacob@woffenden.io>