### PR TITLE
🔧 Update OpenSSL command in AWS SSO CLI setup

### DIFF
--- a/.devcontainer/features/src/aws/install-aws-sso-cli.sh
+++ b/.devcontainer/features/src/aws/install-aws-sso-cli.sh
@@ -31,7 +31,7 @@ install --owner=vscode --group=vscode --mode=775 "$(dirname "${0}")"/src/home/vs
 
 install --owner=vscode --group=vscode --mode=775 "$(dirname "${0}")"/src/home/vscode/.devcontainer/featurerc.d/aws-sso.sh /home/vscode/.devcontainer/featurerc.d/aws-sso.sh
 
-awsSsoFilePassword=$(openssl rand -base64 32)
+awsSsoFilePassword=$(openssl rand -hex 32)
 export awsSsoFilePassword
 
 sed --in-place "s/REPLACE_ME/${awsSsoFilePassword}/g" /home/vscode/.devcontainer/featurerc.d/aws-sso.sh


### PR DESCRIPTION
This pull request:

- Updates OpenSSL command to use `hex` mode, because sometimes `rand` would return a string with a `/`, which breaks the following `sed`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 