### PR TITLE
⏺️ Add Homebridge CNAME

### DIFF
--- a/terraform/cloudflare/records.tf
+++ b/terraform/cloudflare/records.tf
@@ -102,6 +102,14 @@ resource "cloudflare_record" "woffenden_net_homeassistant_cname" {
   proxied = true
 }
 
+resource "cloudflare_record" "woffenden_net_homebridge_cname" {
+  zone_id = module.woffenden_net_cloudflare_zone.id
+  name    = "homebridge"
+  type    = "CNAME"
+  content = cloudflare_tunnel.bny_woffenden_net.cname
+  proxied = true
+}
+
 resource "cloudflare_record" "woffenden_net_bny_a" {
   zone_id = module.woffenden_net_cloudflare_zone.id
   name    = "bny"


### PR DESCRIPTION
This pull request:

- Adds the missing `cloudflare_record` for pointing `homebridge.woffenden.net` at the Cloudflare tunnel

Signed-off-by: Jacob Woffenden <jacob@woffenden.io> 