### PR TITLE
🧻 Bump Paperless-ngx

### DIFF
--- a/terraform/kubernetes/nuc01.int.bny.woffenden.net/deployments.tf
+++ b/terraform/kubernetes/nuc01.int.bny.woffenden.net/deployments.tf
@@ -562,7 +562,7 @@ resource "kubernetes_deployment" "paperless" {
         }
         container {
           name              = "paperless"
-          image             = "ghcr.io/paperless-ngx/paperless-ngx:2.12.0"
+          image             = "ghcr.io/paperless-ngx/paperless-ngx:2.12.1"
           image_pull_policy = "Always"
           env {
             name  = "USERMAP_UID"


### PR DESCRIPTION
This pull request:

- Bumps Paperless-ngx to 2.12.1
  - https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.12.1

Signed-off-by: Jacob Woffenden <jacob@woffenden.io> 