### PR TITLE
🐚 Add Cloudflare SSH application for nuc01

### DIFF
--- a/terraform/cloudflare/records.tf
+++ b/terraform/cloudflare/records.tf
@@ -110,6 +110,14 @@ resource "cloudflare_record" "woffenden_net_homebridge_cname" {
   proxied = true
 }
 
+resource "cloudflare_record" "woffenden_net_ssh_cname" {
+  zone_id = module.woffenden_net_cloudflare_zone.id
+  name    = "ssh"
+  type    = "CNAME"
+  content = cloudflare_tunnel.bny_woffenden_net.cname
+  proxied = true
+}
+
 resource "cloudflare_record" "woffenden_net_bny_a" {
   zone_id = module.woffenden_net_cloudflare_zone.id
   name    = "bny"

--- a/terraform/cloudflare/teams-access-applications.tf
+++ b/terraform/cloudflare/teams-access-applications.tf
@@ -32,3 +32,15 @@ resource "cloudflare_access_application" "homebridge_woffenden_net" {
   http_only_cookie_attribute = true
   allowed_idps               = [data.cloudflare_zero_trust_access_identity_provider.google_workspace.id]
 }
+
+resource "cloudflare_access_application" "ssh_woffenden_net" {
+  account_id                = data.google_secret_manager_secret_version.cloudflare_account_id.secret_data
+  name                      = "SSH"
+  domain                    = "ssh.woffenden.net"
+  type                      = "ssh"
+  session_duration          = "24h"
+  auto_redirect_to_identity = true
+  # logo_url                   = "https://cdn.woffenden.io/zero-trust-assets/homebridge.png"
+  http_only_cookie_attribute = true
+  allowed_idps               = [data.cloudflare_zero_trust_access_identity_provider.google_workspace.id]
+}

--- a/terraform/cloudflare/teams-access-policies.tf
+++ b/terraform/cloudflare/teams-access-policies.tf
@@ -36,3 +36,16 @@ resource "cloudflare_access_policy" "homebridge_woffenden_net" {
     group = [cloudflare_access_group.google_group_ddat_sre.id]
   }
 }
+
+resource "cloudflare_access_policy" "ssh_woffenden_net" {
+  account_id       = data.google_secret_manager_secret_version.cloudflare_account_id.secret_data
+  application_id   = cloudflare_access_application.ssh_woffenden_net.id
+  name             = "allow"
+  precedence       = "1"
+  decision         = "allow"
+  session_duration = "24h"
+
+  include {
+    group = [cloudflare_access_group.google_group_ddat_sre.id]
+  }
+}

--- a/terraform/cloudflare/teams-tunnels-configs.tf
+++ b/terraform/cloudflare/teams-tunnels-configs.tf
@@ -22,6 +22,10 @@ resource "cloudflare_tunnel_config" "bny_woffenden_net" {
       service  = "http://10.100.0.50:8581"
     }
     ingress_rule {
+      hostname = "ssh.woffenden.net"
+      service  = "ssh://10.100.0.50"
+    }
+    ingress_rule {
       service = "http_status:404"
     }
   }


### PR DESCRIPTION
This pull request:

- Adds a new Cloudflare Zero Trust application for browser SSH

This has also been done https://developers.cloudflare.com/cloudflare-one/identity/users/short-lived-certificates/

Signed-off-by: Jacob Woffenden <jacob@woffenden.io> 